### PR TITLE
Add pyproject.toml to cookiecutter repo to setup black and docformatter.

### DIFF
--- a/news/add-precommit.rst
+++ b/news/add-precommit.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add pyproject.toml to cookiecutter repository to configure docformatter and black config.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/{{ cookiecutter.folder_name }}/pyproject.toml
+++ b/{{ cookiecutter.folder_name }}/pyproject.toml
@@ -1,8 +1,3 @@
-[tool.codespell]
-exclude-file = ".codespell/ignore_lines.txt"
-ignore-words = ".codespell/ignore_words.txt"
-skip = "*.cif,*.dat"
-
 [tool.docformatter]
 recursive = true
 wrap-summaries = 72


### PR DESCRIPTION
### What problem does this PR address?

Closes #10 

### What should the reviewer(s) do?

Adding `pyproject.toml` so that users can decided the line-length for black and docformatter 